### PR TITLE
[gradle] Initialize gradle-common-version-catalogs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gradle/common-version-catalogs"]
+	path = gradle/common-version-catalogs
+	url = https://github.com/Omico/gradle-common-version-catalogs

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,7 +32,14 @@ dependencyResolutionManagement {
     }
 }
 
+enableFeaturePreview("VERSION_CATALOGS")
+
 include(":common")
 include(":mobile")
 
 include(":api")
+
+fun createVersionCatalog(name: String) =
+    dependencyResolutionManagement.versionCatalogs.create(name) {
+        from(files("gradle/common-version-catalogs/$name.versions.toml"))
+    }


### PR DESCRIPTION
For easily manage libraries version purpose.